### PR TITLE
Improve client options handling and add helpers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3,7 +3,10 @@
 namespace PhpHttpClient;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
 use PhpHttpClient\Concerns\HttpBehavior;
+use PhpHttpClient\Exceptions\HttpClientException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @final
@@ -12,7 +15,10 @@ class Client implements Contracts\HttpMethods
 {
     use HttpBehavior;
 
+    /** @var GuzzleClient */
     private $instance;
+
+    /** @var array */
     private $options;
     public function __construct(string $baseUri, array $options = [])
     {
@@ -22,38 +28,62 @@ class Client implements Contracts\HttpMethods
 
     public function withQuery(array $query): self
     {
-        $this->options['query'] = $query;
-        return $this;
+        $clone = clone $this;
+        $clone->options['query'] = $query;
+        return $clone;
     }
 
     public function withBody(array $body): self
     {
-        $this->options['body'] = $body;
-        return $this;
+        $clone = clone $this;
+        $clone->options['body'] = $body;
+        return $clone;
+    }
+
+    public function withJson(array $data): self
+    {
+        $clone = clone $this;
+        $clone->options['json'] = $data;
+        return $clone;
+    }
+
+    public function withMiddleware(callable $middleware): self
+    {
+        $clone = clone $this;
+        $handler = $clone->instance->getConfig('handler');
+        if ($handler instanceof HandlerStack) {
+            $handler->push($middleware);
+        }
+
+        return $clone;
     }
 
     public function withOptions(array $options): self
     {
-        $this->options = array_merge($this->options, $options);
-        return $this;
+        $clone = clone $this;
+        $clone->options = array_merge($clone->options, $options);
+        return $clone;
     }
 
     public function withHeaders(array $headers): self
     {
-        $this->options['headers'] = $headers;
-        return $this;
+        $clone = clone $this;
+        $clone->options['headers'] = $headers;
+        return $clone;
     }
 
     public function withBasicAuth(string $username, string $password): self
     {
-        $this->options['auth'] = [$username, $password];
-        return $this;
+        $clone = clone $this;
+        $clone->options['auth'] = [$username, $password];
+        return $clone;
     }
 
     public function withDigestAuth(string $username, string $password): self
     {
-        $this->options['auth'] = [$username, $password, 'digest'];
-        return $this;
+        $clone = clone $this;
+        $clone->options['auth'] = [$username, $password, 'digest'];
+        return $clone;
     }
 
     public function getOptions(): array
@@ -66,11 +96,6 @@ class Client implements Contracts\HttpMethods
         return $this->getInstance()->getConfig('base_uri');
     }
 
-    public function getBaseUrl(): string
-    {
-        return $this->getInstance()->getConfig('base_url');
-    }
-
     public function getHeaders(): array
     {
         return $this->getInstance()->getConfig('headers');
@@ -79,5 +104,18 @@ class Client implements Contracts\HttpMethods
     public function getAuth(): array
     {
         return $this->getInstance()->getConfig('auth');
+    }
+
+    public function getBodyAsString(ResponseInterface $response): string
+    {
+        return (string) $response->getBody();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getJson(ResponseInterface $response, bool $assoc = true)
+    {
+        return json_decode($this->getBodyAsString($response), $assoc);
     }
 }

--- a/src/Concerns/HttpBehavior.php
+++ b/src/Concerns/HttpBehavior.php
@@ -3,6 +3,7 @@ namespace PhpHttpClient\Concerns;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
+use PhpHttpClient\Exceptions\HttpClientException;
 use Psr\Http\Message\ResponseInterface;
 
 trait HttpBehavior
@@ -22,7 +23,13 @@ trait HttpBehavior
      */
     public function request(array $config = []): ResponseInterface
     {
-        return $this->getInstance()->request($config['method'], $config['url'], $config);
+        $merged = array_merge($this->options ?? [], $config);
+
+        try {
+            return $this->getInstance()->request($merged['method'], $merged['url'], $merged);
+        } catch (GuzzleException $e) {
+            throw new HttpClientException($e->getMessage(), (int) $e->getCode(), $e);
+        }
     }
 
     /**

--- a/src/Exceptions/HttpClientException.php
+++ b/src/Exceptions/HttpClientException.php
@@ -1,0 +1,13 @@
+<?php
+namespace PhpHttpClient\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class HttpClientException extends RuntimeException
+{
+    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -1,15 +1,22 @@
 <?php
 
 if (!function_exists('kindOf')) {
-    function kindOf($thing): bool
+    function kindOf($thing): string
     {
-        $str = gettype($thing);
-        return $str || ($str = get_class($thing)) || ($str = get_resource_type($thing)) || ($str = gettype($thing));
+        if (is_object($thing)) {
+            return get_class($thing);
+        }
+
+        if (is_resource($thing)) {
+            return get_resource_type($thing);
+        }
+
+        return gettype($thing);
     }
 }
 
 if (!function_exists('typeOfTest')) {
-    function typeOfTest($type): Closure
+    function typeOfTest(string $type): Closure
     {
         return function ($thing) use ($type) {
             return gettype($thing) === $type;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -57,6 +57,15 @@ it('tests withDigestAuth method', function () {
     expect($result)->toBeInstanceOf(Client::class);
 });
 
+it('tests withJson method', function () {
+    $client = new Client('http://example.com');
+    $data = ['foo' => 'bar'];
+
+    $result = $client->withJson($data);
+
+    expect($result)->toBeInstanceOf(Client::class);
+});
+
 it('tests withQuery method with github api', function () {
     $client = new Client('https://api.github.com');
     $query = ['q' => 'php'];

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -12,3 +12,7 @@ it('should return true if the argument is a buffer', function () {
 it('should return the protocol of the url', function () {
     $this->assertEquals(parseProtocol('https://www.google.com'), 'https');
 });
+
+it('should return the type of the argument', function () {
+    $this->assertEquals('integer', kindOf(1));
+});


### PR DESCRIPTION
## Summary
- make immutable option methods in `Client`
- merge options into requests
- add JSON helper, middleware support, and response helpers
- introduce `HttpClientException`
- refine utility functions
- update tests

## Testing
- `phpunit --bootstrap vendor/autoload.php tests` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_6840e623e2348326a4bc1711d3a3d539